### PR TITLE
Add support to multiple accounts through the x-conta-corrente header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0 (2023-01-09)
+- Add support to multiple accounts through the x-conta-corrente header [#26](https://github.com/lucasrcezimbra/bancointer/pull/26). Thanks @jeanwainer
+
 
 ## 0.0.9 (2023-08-28)
 - Unpin dependencies

--- a/inter/__init__.py
+++ b/inter/__init__.py
@@ -3,4 +3,4 @@ from inter._inter import Inter, Operation, Payment  # noqa
 
 __author__ = """Lucas Rangel Cezimbra"""
 __email__ = 'lucas@cezimbra.tec.br'
-__version__ = '0.0.9'
+__version__ = '0.1.0'

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -39,7 +39,9 @@ class Client:
         defaults to :class:`Scopes.all`
     :type scopes: :class:`Iterable`, optional
     """
-    def __init__(self, client_id, client_secret, cert_path, key_path, account_number=None, scopes=None):
+    def __init__(
+        self, client_id, client_secret, cert_path, key_path, account_number=None, scopes=None
+    ):
         self.client_id = client_id
         self.client_secret = client_secret
         self.cert_path = cert_path

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -39,11 +39,12 @@ class Client:
         defaults to :class:`Scopes.all`
     :type scopes: :class:`Iterable`, optional
     """
-    def __init__(self, client_id, client_secret, cert_path, key_path, scopes=None):
+    def __init__(self, client_id, client_secret, cert_path, key_path, account_number=None, scopes=None):
         self.client_id = client_id
         self.client_secret = client_secret
         self.cert_path = cert_path
         self.key_path = key_path
+        self.account_number = account_number
         self.scopes = scopes or Scopes.all
         self._token = None
 
@@ -68,7 +69,11 @@ class Client:
 
     @property
     def headers(self):
-        return {"Authorization": f"Bearer {self.token}"}
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if self.account_number:
+            headers["x-conta-corrente"] = self.account_number
+
+        return headers
 
     def get_balance(self, date=None):
         params = {}

--- a/inter/_inter.py
+++ b/inter/_inter.py
@@ -27,6 +27,7 @@ class Inter:
         passar um :class:`Client` já inicializado. Útil para testes.
     :type client: Client
     """
+
     def __init__(
         self,
         *,
@@ -34,10 +35,13 @@ class Inter:
         client_secret=None,
         cert_path=None,
         key_path=None,
-        client=None
+        client=None,
+        account_number=None,
     ):
         assert client or (client_id and client_secret and cert_path and key_path)
-        self._client = client or Client(client_id, client_secret, cert_path, key_path)
+        self._client = client or Client(
+            client_id, client_secret, cert_path, key_path, account_number=account_number
+        )
 
     def get_balance(self, date=None):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name="bancointer"
-version = "0.0.9"
+version = "0.1.0"
 description = "Client to consume Banco Inter APIs"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.1.0
 commit = True
 tag = False
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,6 +89,16 @@ def test_headers(client):
     token = str(uuid4())
 
     client._token = token
+
+    assert client.headers == {
+        "Authorization": f"Bearer {client.token}",
+    }
+
+
+def test_headers_account_number(client):
+    token = str(uuid4())
+
+    client._token = token
     client.account_number = "12321"
 
     assert client.headers == {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,9 +84,7 @@ def test_headers(client):
 
     client._token = token
 
-    assert client.headers == {
-        "Authorization": f"Bearer {client.token}",
-    }
+    assert client.headers == {"Authorization": f"Bearer {client.token}"}
 
 
 def test_headers_account_number(client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,15 +10,9 @@ from inter._client import URL
 
 @pytest.fixture
 def client(faker):
-    client_id, client_secret, account_number = (
-        faker.pystr(),
-        faker.pystr(),
-        faker.random_int(),
-    )
+    client_id, client_secret = faker.pystr(), faker.pystr()
     cert_path, key_path = faker.file_path(), faker.file_path()
-    return Client(
-        client_id, client_secret, cert_path, key_path, account_number=account_number
-    )
+    return Client(client_id, client_secret, cert_path, key_path)
 
 
 def test_init(faker):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,9 +10,15 @@ from inter._client import URL
 
 @pytest.fixture
 def client(faker):
-    client_id, client_secret = faker.pystr(), faker.pystr()
+    client_id, client_secret, account_number = (
+        faker.pystr(),
+        faker.pystr(),
+        faker.random_int(),
+    )
     cert_path, key_path = faker.file_path(), faker.file_path()
-    return Client(client_id, client_secret, cert_path, key_path)
+    return Client(
+        client_id, client_secret, cert_path, key_path, account_number=account_number
+    )
 
 
 def test_init(faker):
@@ -83,8 +89,12 @@ def test_headers(client):
     token = str(uuid4())
 
     client._token = token
+    client.account_number = "12321"
 
-    assert client.headers == {"Authorization": f"Bearer {client.token}"}
+    assert client.headers == {
+        "Authorization": f"Bearer {client.token}",
+        "x-conta-corrente": "12321",
+    }
 
 
 @responses.activate

--- a/tests/test_inter.py
+++ b/tests/test_inter.py
@@ -21,6 +21,7 @@ def test_init_from_credentials(faker, mocker):
     cert_path, key_path = faker.file_path(), faker.file_path()
 
     inter = Inter(
+        account_number='123456',
         client_id=client_id,
         client_secret=client_secret,
         cert_path=cert_path,
@@ -28,7 +29,7 @@ def test_init_from_credentials(faker, mocker):
     )
 
     assert isinstance(inter._client, Client)
-    client_mock.assert_called_once_with(client_id, client_secret, cert_path, key_path)
+    client_mock.assert_called_once_with(client_id, client_secret, cert_path, key_path, '123456')
 
 
 def test_get_balance(faker, mocker):


### PR DESCRIPTION
Issue #25: Client accepts an optional `account_number` parameter that will be passed to the `x-conta-corrente` header in the API request. This allows for supporting multiple accounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now specify an account number during client initialization for enhanced interaction with account-specific features.

- **Enhancements**
  - Search functionality now includes account number recognition, improving personalized results.

- **Tests**
  - Updated tests to cover the new account number parameter and ensure headers are set correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->