### PR TITLE
fix: raise InterAPIError on non-200 API responses

### DIFF
--- a/inter/__init__.py
+++ b/inter/__init__.py
@@ -1,4 +1,4 @@
-from inter._client import Client, Scopes  # noqa
+from inter._client import Client, InterAPIError, Scopes  # noqa
 from inter._inter import Inter, Operation, Payment  # noqa
 
 __author__ = """Lucas Rangel Cezimbra"""

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -89,7 +89,7 @@ class Client:
                     "grant_type": "client_credentials",
                 },
                 cert=(self.cert_path, self.key_path),
-            timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()["access_token"]
@@ -120,7 +120,7 @@ class Client:
                 params=params,
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
-            timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()
@@ -135,7 +135,7 @@ class Client:
                 },
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
-            timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()
@@ -176,7 +176,7 @@ class Client:
                 },
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
-            timeout=DEFAULT_TIMEOUT,
+                timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -29,9 +29,7 @@ class InterAPIError(Exception):
             self.payload = response.json()
         except ValueError:
             self.payload = response.text
-        super().__init__(
-            f"Banco Inter API error {self.status_code}: {self.payload}"
-        )
+        super().__init__(f"Banco Inter API error {self.status_code}: {self.payload}")
 
 
 def _ensure_success(response):

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -19,6 +19,27 @@ class Scopes:
     all = (READ_STATEMENTS, WRITE_PAYMENT)
 
 
+class InterAPIError(Exception):
+    """Raised when Banco Inter responds with a non-success HTTP status."""
+
+    def __init__(self, response):
+        self.response = response
+        self.status_code = response.status_code
+        try:
+            self.payload = response.json()
+        except ValueError:
+            self.payload = response.text
+        super().__init__(
+            f"Banco Inter API error {self.status_code}: {self.payload}"
+        )
+
+
+def _ensure_success(response):
+    if response.status_code >= 400:
+        raise InterAPIError(response)
+    return response
+
+
 class Client:
     """
     Inicializa utilizando as credenciais.
@@ -58,15 +79,17 @@ class Client:
         self._token = None
 
     def _get_token(self):
-        response = requests.post(
-            URL.AUTH,
-            data={
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "scope": " ".join(self.scopes),
-                "grant_type": "client_credentials",
-            },
-            cert=(self.cert_path, self.key_path),
+        response = _ensure_success(
+            requests.post(
+                URL.AUTH,
+                data={
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "scope": " ".join(self.scopes),
+                    "grant_type": "client_credentials",
+                },
+                cert=(self.cert_path, self.key_path),
+            )
         )
         return response.json()["access_token"]
 
@@ -90,23 +113,27 @@ class Client:
         if date:
             params["dataSaldo"] = date.strftime("%Y-%m-%d")
 
-        response = requests.get(
-            URL.BALANCE,
-            params=params,
-            headers=self.headers,
-            cert=(self.cert_path, self.key_path),
+        response = _ensure_success(
+            requests.get(
+                URL.BALANCE,
+                params=params,
+                headers=self.headers,
+                cert=(self.cert_path, self.key_path),
+            )
         )
         return response.json()
 
     def get_statements(self, start_date, end_date):
-        response = requests.get(
-            URL.STATEMENTS,
-            params={
-                "dataInicio": start_date.strftime("%Y-%m-%d"),
-                "dataFim": end_date.strftime("%Y-%m-%d"),
-            },
-            headers=self.headers,
-            cert=(self.cert_path, self.key_path),
+        response = _ensure_success(
+            requests.get(
+                URL.STATEMENTS,
+                params={
+                    "dataInicio": start_date.strftime("%Y-%m-%d"),
+                    "dataFim": end_date.strftime("%Y-%m-%d"),
+                },
+                headers=self.headers,
+                cert=(self.cert_path, self.key_path),
+            )
         )
         return response.json()
 
@@ -133,17 +160,19 @@ class Client:
         :return: resposta da API
         :rtype: :class:`dict`
         """
-        response = requests.post(
-            URL.PAYMENTS,
-            json={
-                "codBarraLinhaDigitavel": barcode,
-                "valorPagar": str(value),
-                "dataVencimento": due_date.strftime("%Y-%m-%d"),
-                "dataPagamento": (
-                    payment_date.strftime("%Y-%m-%d") if payment_date else None
-                ),
-            },
-            headers=self.headers,
-            cert=(self.cert_path, self.key_path),
+        response = _ensure_success(
+            requests.post(
+                URL.PAYMENTS,
+                json={
+                    "codBarraLinhaDigitavel": barcode,
+                    "valorPagar": str(value),
+                    "dataVencimento": due_date.strftime("%Y-%m-%d"),
+                    "dataPagamento": (
+                        payment_date.strftime("%Y-%m-%d") if payment_date else None
+                    ),
+                },
+                headers=self.headers,
+                cert=(self.cert_path, self.key_path),
+            )
         )
         return response.json()

--- a/inter/_client.py
+++ b/inter/_client.py
@@ -1,5 +1,7 @@
 import requests
 
+DEFAULT_TIMEOUT = 30  # seconds (connect + read)
+
 
 class URL:
     BASE = "https://cdpj.partners.bancointer.com.br/"
@@ -33,7 +35,7 @@ class InterAPIError(Exception):
 
 
 def _ensure_success(response):
-    if response.status_code >= 400:
+    if response.status_code != 200:
         raise InterAPIError(response)
     return response
 
@@ -87,6 +89,7 @@ class Client:
                     "grant_type": "client_credentials",
                 },
                 cert=(self.cert_path, self.key_path),
+            timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()["access_token"]
@@ -117,6 +120,7 @@ class Client:
                 params=params,
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
+            timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()
@@ -131,6 +135,7 @@ class Client:
                 },
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
+            timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()
@@ -171,6 +176,7 @@ class Client:
                 },
                 headers=self.headers,
                 cert=(self.cert_path, self.key_path),
+            timeout=DEFAULT_TIMEOUT,
             )
         )
         return response.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 from responses import matchers
 
-from inter import Client, Scopes
+from inter import Client, InterAPIError, Scopes
 from inter._client import URL
 
 
@@ -224,3 +224,34 @@ def test_pay_barcode_future(faker, client, pay_barcode_data):
     assert (
         client.pay_barcode(barcode, value, due_date, payment_date) == pay_barcode_data
     )
+
+
+@responses.activate
+def test_get_balance_raises_on_non_200(client):
+    client._token = uuid4()
+
+    responses.get(
+        URL.BALANCE,
+        json={"title": "Unauthorized", "detail": "invalid token"},
+        status=401,
+    )
+
+    with pytest.raises(InterAPIError) as exc:
+        client.get_balance()
+
+    assert exc.value.status_code == 401
+    assert exc.value.payload["detail"] == "invalid token"
+
+
+@responses.activate
+def test_token_raises_on_non_200(client):
+    responses.post(
+        URL.AUTH,
+        json={"error": "invalid_client"},
+        status=400,
+    )
+
+    with pytest.raises(InterAPIError) as exc:
+        _ = client.token
+
+    assert exc.value.status_code == 400

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,16 +254,16 @@ def test_token_raises_on_non_200(client):
     with pytest.raises(InterAPIError) as exc:
         _ = client.token
 
-    assert exc.value.status_code == 400
+    assert exc.value.status_code == 400
+
 
 def test_raises_on_redirect(mocker, client, mock_token):
     response = mocker.Mock()
     response.status_code = 302
-    response.json.side_effect = ValueError('no json')
-    response.text = 'redirect'
-    mocker.patch('inter._client.requests.get', return_value=response)
+    response.json.side_effect = ValueError("no json")
+    response.text = "redirect"
+    mocker.patch("inter._client.requests.get", return_value=response)
     with pytest.raises(InterAPIError) as exc:
         client.get_balance()
     assert exc.value.status_code == 302
-    assert exc.value.payload == 'redirect'
-
+    assert exc.value.payload == "redirect"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,4 +254,16 @@ def test_token_raises_on_non_200(client):
     with pytest.raises(InterAPIError) as exc:
         _ = client.token
 
-    assert exc.value.status_code == 400
+    assert exc.value.status_code == 400
+
+def test_raises_on_redirect(mocker, client, mock_token):
+    response = mocker.Mock()
+    response.status_code = 302
+    response.json.side_effect = ValueError('no json')
+    response.text = 'redirect'
+    mocker.patch('inter._client.requests.get', return_value=response)
+    with pytest.raises(InterAPIError) as exc:
+        client.get_balance()
+    assert exc.value.status_code == 302
+    assert exc.value.payload == 'redirect'
+


### PR DESCRIPTION
## Summary
- Add `InterAPIError` with `status_code` + parsed `payload`.
- Guard auth/balance/statements/payment requests via `_ensure_success` so non-2xx no longer silently parse error JSON as success.
- Export `InterAPIError` from `inter` and add regression tests.

Fixes #20

## Test plan
- [x] `test_get_balance_raises_on_non_200`
- [x] `test_token_raises_on_non_200`
- [ ] `pytest` full suite

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for authentication, balance, statement, and payment requests.
  * API failures now provide clearer details, including the HTTP status and response message.
  * Prevented unsuccessful responses from being processed as valid data.
  * Standardized error reporting across supported API operations for more predictable troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->