### PR TITLE
docs: restore Testing sections on RTD (add faker to docs extras)

### DIFF
--- a/docs/high-level-api.rst
+++ b/docs/high-level-api.rst
@@ -11,7 +11,20 @@ API
 
 
 Testing
-----------
+-------
+
+Use :class:`inter.testing.InterFake` in unit tests so you do not call the live
+Banco Inter API. Override ``balance``, ``statement``, or ``pay_barcode_data``
+to control return values.
+
+Example::
+
+    from decimal import Decimal
+    from inter.testing import InterFake
+
+    inter = InterFake()
+    inter.balance = Decimal("1000.00")
+    assert inter.get_balance() == Decimal("1000.00")
 
 .. automodule:: inter.testing
    :members: InterFake

--- a/docs/low-level-api.rst
+++ b/docs/low-level-api.rst
@@ -13,6 +13,18 @@ API
 Testing
 -------
 
+Use :class:`inter.testing.ClientFake` when you need the low-level client shape
+without network or certificates. Override ``balance``, ``statements``, or
+``pay_barcode_data`` on the instance.
+
+Example::
+
+    from inter.testing import ClientFake
+
+    client = ClientFake()
+    client.balance = {"disponivel": 42.5}
+    assert client.get_balance() == {"disponivel": 42.5}
+
 .. automodule:: inter.testing
    :members: ClientFake
    :undoc-members:

--- a/inter/testing.py
+++ b/inter/testing.py
@@ -10,7 +10,7 @@ faker = Faker()
 
 def generate_operation_data():
     return {
-        "dataEntrada": faker.date(),
+        "dataEntrada": faker.date().isoformat(),
         "tipoTransacao": random.choice(Operation.TYPES),
         "tipoOperacao": random.choice(("C", "D")),
         "valor": str(faker.pyfloat(right_digits=2, positive=True)),
@@ -80,6 +80,9 @@ class InterFake(Inter):
     def __init__(self, *args, **kwargs):
         client = ClientFake()
         self.balance = faker.pydecimal(right_digits=2)
+        self.statement = [
+            Operation.from_data(item) for item in client.statements["transacoes"]
+        ]
         self.pay_barcode_data = Payment.from_data(client.pay_barcode_data)
 
     def get_balance(self, date=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ build = [
   "flit>=3.4"
 ]
 docs = [
+  "faker==40.1.0",
   "myst-parser==4.0.1",
   "Sphinx==8.2.3",
   "sphinx-rtd-theme==3.1.0",


### PR DESCRIPTION
## Summary
- Add `faker` to the `docs` optional dependencies so Read the Docs can import `inter.testing` (root cause of empty Testing sections).
- Add short narrative + examples under Testing in high/low-level API docs.
- Initialize `InterFake.statement` from fake operations and normalize `dataEntrada` to ISO dates.

Fixes #21

## Why
RTD installs only `.[docs]`. Without `faker`, autodoc for `inter.testing` fails and the Testing anchors render empty.

## Test plan
- [ ] RTD build imports `inter.testing` and renders InterFake / ClientFake
- [ ] Doctests in `inter.testing` still pass with faker available

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using testing fakes in high- and low-level API unit tests.
  * Documented offline testing without network access or certificates.
  * Included examples for configuring and validating balance responses.

* **Bug Fixes**
  * Improved generated test transaction data by using ISO-formatted dates.
  * Ensured fake statements provide properly structured operation objects for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->